### PR TITLE
pipenv setup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+layout pipenv

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,19 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+pytest = "*"
+crypto-dom = {editable = true, path = "."}
+
+[packages]
+httpx = "*"
+pydantic = "*"
+pytest-asyncio = "*"
+stackprinter = "*"
+typing-extensions = "*"
+returns = "*"
+
+[requires]
+python_version = "3.9"


### PR DESCRIPTION
simple pipenv setup. duplicates `requirements.txt` so it is suitable to generate `requirements.txt` from pipenv as explained in https://pipenv-fork.readthedocs.io/en/latest/advanced.html#generating-a-requirements-txt?

I didnt include `Pipfile.lock` as we are likely supporting python versions.